### PR TITLE
request-tailored thing description

### DIFF
--- a/src/exposed-thing.ts
+++ b/src/exposed-thing.ts
@@ -166,11 +166,11 @@ export default class ExposedThing implements WoT.DynamicThing {
     /**
      * Retrive the ExposedThing description for this object
      */
-    getDescription(): Object {
+    getDescription(forHost? : string): Object {
         //this is downright madness - TODO clean it up soon
         return JSON.parse(
             TDParser.serializeTD(
-                TDParser.generateTD(this, this.srv)
+                TDParser.generateTD(this, this.srv, forHost)
             )
         )
     }

--- a/src/protocols/address-helper.ts
+++ b/src/protocols/address-helper.ts
@@ -27,7 +27,7 @@ const os = require("os");
 
 export default class AddressHelper {
 
-    public static getAddresses() : Array<string> {
+    public static getAddresses(requestHost? : string) : Array<string> {
         let addresses : Array<any> = [];
 
         let interfaces = os.networkInterfaces();
@@ -43,6 +43,10 @@ export default class AddressHelper {
         }
 
         addresses.push("127.0.0.1");
+
+        if(requestHost && addresses.indexOf(requestHost)===-1) {
+            addresses.push(requestHost)
+        }
 
         logger.verbose(`AddressHelper identified ${addresses}`);
 

--- a/src/resource-listeners/td-resource-listener.ts
+++ b/src/resource-listeners/td-resource-listener.ts
@@ -37,4 +37,8 @@ export default class TDResourceListener extends BasicResourceListener implements
     public onRead() : Promise<Content> {
         return Promise.resolve(ContentSerdes.valueToBytes(this.thing.getDescription()));
     }
+
+    public onReadForHost(host : string) {
+        return Promise.resolve(ContentSerdes.valueToBytes(this.thing.getDescription(host)));
+    } 
 }

--- a/src/td/td-parser.ts
+++ b/src/td/td-parser.ts
@@ -106,7 +106,7 @@ export function serializeTD(td : ThingDescription) : string {
 * @param thing
 * @param servient
 */
-export function generateTD(thing : ExposedThing, servient : Servient ) : ThingDescription {
+export function generateTD(thing : ExposedThing, servient : Servient, requestHost? : string ) : ThingDescription {
 
     logger.silly(`generateTD() \n\`\`\`\n${thing}\n\`\`\``);
 
@@ -143,15 +143,14 @@ export function generateTD(thing : ExposedThing, servient : Servient ) : ThingDe
 
       let l = 0
       /* for each address, supported protocol, and media type an intreaction resouce is generated */
-      for (let add of   AddressHelper.getAddresses()) {
+      for (let add of   AddressHelper.getAddresses(requestHost)) {
         for(let ser of servient.getServers()) {
           for(let med of servient.getSupportedMediaTypes()) {
 
             /* if server is online !==-1 assign the href information */
             if(ser.getPort()!==-1) {
                 let href:string = ser.getScheme()+"://" +add+":"+ser.getPort()+"/" + thing.name
-
-          
+         
                 /* depending of the resource pattern, uri is constructed */
                 if(interaction.pattern === TD.InteractionPattern.Property) {
                       interaction.links[l] = new TD.InteractionLink()


### PR DESCRIPTION
enable generating a thing description on the fly with scheme and the host part of the URI matching the reuquest