### PR TITLE
replacing typedjson git reference with typedjson-npm

### DIFF
--- a/packages/node-wot-td-tools/package.json
+++ b/packages/node-wot-td-tools/package.json
@@ -26,6 +26,6 @@
   "dependencies": {
     "node-wot-helpers": "^0.1.0",
     "node-wot-logger": "^0.1.0",
-    "typedjson": "git+https://github.com/JohnWeisz/TypedJSON.git"
+    "typedjson-npm": "^0.1.7"
   }
 }

--- a/packages/node-wot-td-tools/src/td-parser.ts
+++ b/packages/node-wot-td-tools/src/td-parser.ts
@@ -24,7 +24,7 @@ import ThingDescription from './thing-description';
 import * as TD from './thing-description';
 import * as AddressHelper from 'node-wot-helpers';
 
-import { JsonMember, JsonObject, TypedJSON } from 'typedjson';
+import { JsonMember, JsonObject, TypedJSON } from 'typedjson-npm';
 
 export function parseTDObject(td: Object): ThingDescription {
   // FIXME Is this the best way to verify?

--- a/packages/node-wot-td-tools/src/thing-description.ts
+++ b/packages/node-wot-td-tools/src/thing-description.ts
@@ -18,7 +18,7 @@
  * DEALINGS IN THE SOFTWARE.
  */
 
-import { JsonMember, JsonObject } from 'typedjson';
+import { JsonMember, JsonObject } from 'typedjson-npm';
 
 /** Internet Media Types */
 /*export enum MediaType {


### PR DESCRIPTION
typedjson 0.1.7 is availiable as typedjson-npm.

This replaces the git reference which causes problems behind proxies