### PR TITLE
Add webpack bundle building to node-wot-td-tools

### DIFF
--- a/packages/node-wot-td-tools/package.json
+++ b/packages/node-wot-td-tools/package.json
@@ -9,7 +9,7 @@
   "typings": "dist/td-tools.d.ts",
   "scripts": {
     "test": "mocha --compilers ts:ts-node/register",
-    "build": "tsc",
+    "build": "tsc && webpack",
     "codestyle": "standard --pretty"
   },
   "author": "the thingweb community",
@@ -20,9 +20,11 @@
     "chai": "4.1.2",
     "mocha": "3.5.3",
     "mocha-typescript": "1.1.8",
+    "ts-loader": "^3.2.0",
     "ts-node": "3.3.0",
     "typescript": "2.5.2",
-    "typescript-standard": "0.3.30"
+    "typescript-standard": "0.3.30",
+    "webpack": "^3.10.0"
   },
   "dependencies": {
     "reflect-metadata": "0.1.10",

--- a/packages/node-wot-td-tools/webpack.config.js
+++ b/packages/node-wot-td-tools/webpack.config.js
@@ -1,0 +1,16 @@
+const path = require('path');
+
+module.exports = {
+   entry: "./src/td-tools.ts",
+   output: {
+       filename: "node-wot-td-tools.bundle.js",
+       path: path.resolve(__dirname, 'dist'),
+       library: "NodeWotTdTools"
+   },
+   resolve: {
+       extensions: [".ts", ".js"]
+   },
+   module: {
+       loaders: [{ test: /\.ts$/, loader: "ts-loader" }]
+   }
+}


### PR DESCRIPTION
The `node-wot-td-tools` package is useful not only in server scenarios
using `node`, but also in browsers. To support usage in browsers, the
classes need to be bundled, resolving the modules used in the sources.

This change introduces `webpack` to create a bundle file as part of the
build process. You will find the resulting bundle in
`dist/node-wot-td-tools.bundle.js`.

To use classes are available on the global `NodeWotTdTools` object.