### PR TITLE
feat: add JSON mimetype support for 'application/senml+json'

### DIFF
--- a/packages/core/src/content-serdes.ts
+++ b/packages/core/src/content-serdes.ts
@@ -38,8 +38,19 @@ export class Content {
 
 /** default implementation offerin Json de-/serialisation */
 class JsonCodec implements ContentCodec {
+
+  private mimeType : string;
+
+  constructor(mimeType? : string) {
+    if(mimeType == null) {
+      this.mimeType = ContentSerdes.DEFAULT; // 'application/json' 
+    } else {
+      this.mimeType = mimeType;
+    }
+  }
+
   getMediaType(): string {
-    return 'application/json'
+    return this.mimeType;
   }
 
   bytesToValue(bytes: Buffer): any {
@@ -119,6 +130,7 @@ export class ContentSerdes {
     if (!this.instance) {
       this.instance = new ContentSerdes();
       this.instance.addCodec(new JsonCodec());
+      this.instance.addCodec(new JsonCodec('application/senml+json'));
       this.instance.addCodec(new TextCodec());
     }
     return this.instance;

--- a/packages/core/src/content-serdes.ts
+++ b/packages/core/src/content-serdes.ts
@@ -39,18 +39,18 @@ export class Content {
 /** default implementation offerin Json de-/serialisation */
 class JsonCodec implements ContentCodec {
 
-  private mimeType : string;
+  private subMediaType: string;
 
-  constructor(mimeType? : string) {
-    if(mimeType == null) {
-      this.mimeType = ContentSerdes.DEFAULT; // 'application/json' 
+  constructor(subMediaType?: string) {
+    if(!subMediaType) {
+      this.subMediaType = ContentSerdes.DEFAULT; // 'application/json' 
     } else {
-      this.mimeType = mimeType;
+      this.subMediaType = subMediaType;
     }
   }
 
   getMediaType(): string {
-    return this.mimeType;
+    return this.subMediaType;
   }
 
   bytesToValue(bytes: Buffer): any {


### PR DESCRIPTION
Unfortunately it is not that easy with the current code style to add "+json" rule.
Hence, an additional codec is registered for 'application/senml+json'